### PR TITLE
CAVE UI Fixes and Improvements

### DIFF
--- a/cave/addtag.py
+++ b/cave/addtag.py
@@ -1,14 +1,14 @@
 import sys
 import os
 
-from gi.repository import Gtk
+from gi.repository import Gtk, Gdk
 from misc.log import with_logging
 
 from libcave.registered_elements import get_registered_elements, get_registered_elements_implementing
 from libcave.tags.registered_tags import get_tagtype_names, get_required_functions_of_tag
 from libcave.util import populate_combo_box
 
-__location__ = os.path.dirname(os.path.realpath(os.path.abspath(sys.argv[0]))) 
+__location__ = os.path.dirname(os.path.realpath(os.path.abspath(sys.argv[0])))
 
 @with_logging
 class AddTag:
@@ -73,11 +73,11 @@ class AddTag:
         self.gladefile = os.path.join(__location__, "gui", "addtag.glade")
         self.builder = Gtk.Builder()
         self.builder.add_from_file(self.gladefile)
-        
+
         # Automatically connect signals to functions defined above
         # not needed in commandline
         self.builder.connect_signals(self)
-        
+
         self.mission_element_combo = self.builder.get_object("missionElementCombo")
         self.tag_type_combo = self.builder.get_object("tagTypeCombo")
         self.tag_name_entry = self.builder.get_object("tagNameEntry")
@@ -90,8 +90,8 @@ class AddTag:
 
         #Get the main window
         self.window = self.builder.get_object("addTagWindow")
+        self.window.set_type_hint(Gdk.WindowTypeHint.DIALOG)
         self.window.show()
-
 
         #Link callback
         self.callback = callback

--- a/cave/addvideo.py
+++ b/cave/addvideo.py
@@ -2,12 +2,12 @@
 import sys
 import os
 
-from gi.repository import Gtk
+from gi.repository import Gtk, Gdk
 from misc.log import with_logging
 from libcave.cameralink import camera_map
 from meta import MetaParser
 
-__location__ = os.path.dirname(os.path.realpath(os.path.abspath(sys.argv[0]))) 
+__location__ = os.path.dirname(os.path.realpath(os.path.abspath(sys.argv[0])))
 
 @with_logging
 class AddVideo:
@@ -76,7 +76,7 @@ class AddVideo:
         self.log_path = self.builder.get_object("logPathChooser")
         self.video_name_entry = self.builder.get_object("videoNameEntry")
         self.meta_entry = self.builder.get_object("metaEntry")
-        
+
         #Set default folders for the file-buttons
         if default_folder is not None:
             self.video_path.set_current_folder(default_folder)
@@ -94,6 +94,7 @@ class AddVideo:
 
         #Get the main window
         self.window = self.builder.get_object("addVideoWindow")
+        self.window.set_type_hint(Gdk.WindowTypeHint.DIALOG)
         self.window.show()
 
         #Link callback

--- a/cave/genericGladeParser.py
+++ b/cave/genericGladeParser.py
@@ -2,14 +2,14 @@
 import sys
 import os
 
-from gi.repository import Gtk
+from gi.repository import Gtk, Gdk
 from misc.log import with_logging
 
 from registered_elements import get_registered_elements, get_registered_elements_implementing
 from tags.registered_tags import get_tagtype_names, get_required_functions_of_tag
 from util import populate_combo_box
 
-__location__ = os.path.dirname(os.path.realpath(os.path.abspath(sys.argv[0]))) 
+__location__ = os.path.dirname(os.path.realpath(os.path.abspath(sys.argv[0])))
 
 @with_logging
 class GenericGladeParser:
@@ -72,10 +72,10 @@ class GenericGladeParser:
         self.gladefile = os.path.join(__location__, location)
         self.builder = Gtk.Builder()
         self.builder.add_from_file(self.gladefile)
-        
+
         # Automatically connect signals to functions defined above
         self.builder.connect_signals(self)
-        
+
         #Populate dropdowns
         self.elements = get_registered_elements().keys()
         self.elements.sort()
@@ -84,8 +84,8 @@ class GenericGladeParser:
 
         #Get the main window
         self.window = self.builder.get_object("addTagWindow")
+        self.window.set_type_hint(Gdk.WindowTypeHint.DIALOG)
         self.window.show()
-
 
         #Link callback
         self.callback = callback

--- a/cave/gui/addtag.glade
+++ b/cave/gui/addtag.glade
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.0 -->
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.10"/>
   <object class="GtkWindow" id="addTagWindow">
     <property name="width_request">300</property>
     <property name="can_focus">False</property>
@@ -44,8 +45,6 @@
               <packing>
                 <property name="left_attach">0</property>
                 <property name="top_attach">0</property>
-                <property name="width">1</property>
-                <property name="height">1</property>
               </packing>
             </child>
             <child>
@@ -59,8 +58,6 @@
               <packing>
                 <property name="left_attach">0</property>
                 <property name="top_attach">1</property>
-                <property name="width">1</property>
-                <property name="height">1</property>
               </packing>
             </child>
             <child>
@@ -69,13 +66,10 @@
                 <property name="can_focus">True</property>
                 <property name="hexpand">True</property>
                 <property name="invisible_char">•</property>
-                <property name="invisible_char_set">True</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>
                 <property name="top_attach">0</property>
-                <property name="width">1</property>
-                <property name="height">1</property>
               </packing>
             </child>
             <child>
@@ -89,8 +83,6 @@
               <packing>
                 <property name="left_attach">0</property>
                 <property name="top_attach">2</property>
-                <property name="width">1</property>
-                <property name="height">1</property>
               </packing>
             </child>
             <child>
@@ -103,8 +95,6 @@
               <packing>
                 <property name="left_attach">1</property>
                 <property name="top_attach">1</property>
-                <property name="width">1</property>
-                <property name="height">1</property>
               </packing>
             </child>
             <child>
@@ -116,8 +106,6 @@
               <packing>
                 <property name="left_attach">1</property>
                 <property name="top_attach">2</property>
-                <property name="width">1</property>
-                <property name="height">1</property>
               </packing>
             </child>
           </object>
@@ -199,8 +187,6 @@
                   <packing>
                     <property name="left_attach">1</property>
                     <property name="top_attach">0</property>
-                    <property name="width">1</property>
-                    <property name="height">1</property>
                   </packing>
                 </child>
                 <child>
@@ -215,8 +201,6 @@
                   <packing>
                     <property name="left_attach">0</property>
                     <property name="top_attach">0</property>
-                    <property name="width">1</property>
-                    <property name="height">1</property>
                   </packing>
                 </child>
               </object>

--- a/cave/gui/addvideo.glade
+++ b/cave/gui/addvideo.glade
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.0 -->
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.10"/>
   <object class="GtkWindow" id="addVideoWindow">
     <property name="width_request">300</property>
     <property name="can_focus">False</property>
@@ -45,8 +46,6 @@
               <packing>
                 <property name="left_attach">0</property>
                 <property name="top_attach">0</property>
-                <property name="width">1</property>
-                <property name="height">1</property>
               </packing>
             </child>
             <child>
@@ -60,8 +59,6 @@
               <packing>
                 <property name="left_attach">0</property>
                 <property name="top_attach">1</property>
-                <property name="width">1</property>
-                <property name="height">1</property>
               </packing>
             </child>
             <child>
@@ -69,14 +66,11 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="hexpand">True</property>
-                <property name="orientation">vertical</property>
                 <property name="title" translatable="yes">Select a Log File</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>
                 <property name="top_attach">1</property>
-                <property name="width">1</property>
-                <property name="height">1</property>
               </packing>
             </child>
             <child>
@@ -84,14 +78,11 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="hexpand">True</property>
-                <property name="orientation">vertical</property>
                 <property name="title" translatable="yes">Select a Video File</property>
               </object>
               <packing>
                 <property name="left_attach">1</property>
                 <property name="top_attach">0</property>
-                <property name="width">1</property>
-                <property name="height">1</property>
               </packing>
             </child>
             <child>
@@ -105,8 +96,6 @@
               <packing>
                 <property name="left_attach">0</property>
                 <property name="top_attach">3</property>
-                <property name="width">1</property>
-                <property name="height">1</property>
               </packing>
             </child>
             <child>
@@ -117,8 +106,6 @@
               <packing>
                 <property name="left_attach">1</property>
                 <property name="top_attach">3</property>
-                <property name="width">1</property>
-                <property name="height">1</property>
               </packing>
             </child>
             <child>
@@ -132,8 +119,6 @@
               <packing>
                 <property name="left_attach">0</property>
                 <property name="top_attach">2</property>
-                <property name="width">1</property>
-                <property name="height">1</property>
               </packing>
             </child>
             <child>
@@ -145,8 +130,6 @@
               <packing>
                 <property name="left_attach">1</property>
                 <property name="top_attach">2</property>
-                <property name="width">1</property>
-                <property name="height">1</property>
               </packing>
             </child>
             <child>
@@ -160,8 +143,6 @@
               <packing>
                 <property name="left_attach">0</property>
                 <property name="top_attach">4</property>
-                <property name="width">1</property>
-                <property name="height">1</property>
               </packing>
             </child>
             <child>
@@ -173,8 +154,6 @@
               <packing>
                 <property name="left_attach">1</property>
                 <property name="top_attach">4</property>
-                <property name="width">1</property>
-                <property name="height">1</property>
               </packing>
             </child>
           </object>
@@ -256,8 +235,6 @@
                   <packing>
                     <property name="left_attach">1</property>
                     <property name="top_attach">0</property>
-                    <property name="width">1</property>
-                    <property name="height">1</property>
                   </packing>
                 </child>
                 <child>
@@ -272,8 +249,6 @@
                   <packing>
                     <property name="left_attach">0</property>
                     <property name="top_attach">0</property>
-                    <property name="width">1</property>
-                    <property name="height">1</property>
                   </packing>
                 </child>
               </object>
@@ -295,7 +270,6 @@
           <object class="GtkLabel" id="label7">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="xpad">10</property>
             <property name="label" translatable="yes">&lt;i&gt;&lt;b&gt;Filesystem Warning&lt;/b&gt;&lt;/i&gt;
 Due to strange opencv behavior, it is recommended that you
 keep video files on a Linux ext filesystem. Strange / inconsistent

--- a/cave/gui/cave.glade
+++ b/cave/gui/cave.glade
@@ -192,7 +192,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <child>
-              <object class="GtkBox" id="box1">
+              <object class="GtkBox" id="panelBox">
                 <property name="width_request">200</property>
                 <property name="height_request">350</property>
                 <property name="visible">True</property>
@@ -489,7 +489,23 @@ All Tags</property>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">True</property>
-                                <property name="position">3</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="fullScreenCheck">
+                                <property name="label" translatable="yes">Compact</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="tooltip_text" translatable="yes">Hides all the useless parts of the CAVE UI.</property>
+                                <property name="draw_indicator">True</property>
+                                <signal name="toggled" handler="full_screen_checked" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
                               </packing>
                             </child>
                           </object>
@@ -507,7 +523,7 @@ All Tags</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" id="box7">
+                      <object class="GtkBox" id="settingsBox">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="orientation">vertical</property>

--- a/cave/gui/cave.glade
+++ b/cave/gui/cave.glade
@@ -1,6 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.0 -->
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.10"/>
+  <object class="GtkImage" id="image1">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-add</property>
+  </object>
+  <object class="GtkImage" id="image2">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-edit</property>
+  </object>
+  <object class="GtkImage" id="image3">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-new</property>
+  </object>
+  <object class="GtkImage" id="image4">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="stock">gtk-open</property>
+  </object>
   <object class="GtkWindow" id="caveWindow">
     <property name="width_request">1000</property>
     <property name="height_request">600</property>
@@ -227,6 +248,9 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <signal name="cursor-changed" handler="videotree_selected" swapped="no"/>
+                        <child internal-child="selection">
+                          <object class="GtkTreeSelection"/>
+                        </child>
                       </object>
                     </child>
                   </object>
@@ -466,7 +490,6 @@ All Tags</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>
                                     <property name="tooltip_text" translatable="yes">Run "auv-visiond cave_test" to view these frames</property>
-                                    <property name="xalign">0</property>
                                     <property name="draw_indicator">True</property>
                                     <signal name="toggled" handler="frames_to_vision_checked" swapped="no"/>
                                   </object>
@@ -601,7 +624,6 @@ Log Playback</property>
                                         <property name="receives_default">False</property>
                                         <property name="has_tooltip">True</property>
                                         <property name="tooltip_text" translatable="yes">Enable / disable output of log data to shared memory</property>
-                                        <property name="xalign">0</property>
                                         <property name="draw_indicator">True</property>
                                         <signal name="toggled" handler="frames_to_log_checked" swapped="no"/>
                                       </object>
@@ -620,7 +642,6 @@ Previews</property>
                                         <property name="receives_default">False</property>
                                         <property name="tooltip_text" translatable="yes">Video previews in the timeline can be disabled
 if performance is a concern (low powered systems)</property>
-                                        <property name="xalign">0</property>
                                         <property name="active">True</property>
                                         <property name="draw_indicator">True</property>
                                         <signal name="toggled" handler="enable_video_previews" swapped="no"/>
@@ -733,26 +754,5 @@ if performance is a concern (low powered systems)</property>
         </child>
       </object>
     </child>
-  </object>
-  <object class="GtkImage" id="image1">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="xalign">0.44999998807907104</property>
-    <property name="stock">gtk-add</property>
-  </object>
-  <object class="GtkImage" id="image2">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-edit</property>
-  </object>
-  <object class="GtkImage" id="image3">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-new</property>
-  </object>
-  <object class="GtkImage" id="image4">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-open</property>
   </object>
 </interface>

--- a/cave/gui/cave.glade
+++ b/cave/gui/cave.glade
@@ -158,28 +158,6 @@
                 </child>
               </object>
             </child>
-            <child>
-              <object class="GtkMenuItem" id="helpMenu">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Help</property>
-                <child type="submenu">
-                  <object class="GtkMenu" id="menu3">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkImageMenuItem" id="imagemenuitem10">
-                        <property name="label">gtk-about</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/cave/gui/cave.glade
+++ b/cave/gui/cave.glade
@@ -188,7 +188,7 @@
           </packing>
         </child>
         <child>
-          <object class="GtkPaned" id="paned1">
+          <object class="GtkPaned" id="mainPaned">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <child>
@@ -199,7 +199,7 @@
                 <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkBox" id="box5">
+                  <object class="GtkBox" id="searchBox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="homogeneous">True</property>
@@ -239,7 +239,7 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkScrolledWindow" id="scrolledwindow1">
+                  <object class="GtkScrolledWindow" id="videoTreeScroll">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="shadow_type">in</property>
@@ -261,12 +261,12 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkBox" id="box8">
+                  <object class="GtkBox" id="databaseButtons">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="orientation">vertical</property>
                     <child>
-                      <object class="GtkButtonBox" id="buttonbox3">
+                      <object class="GtkButtonBox" id="buttonsRow1">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="spacing">2</property>
@@ -339,7 +339,7 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkButtonBox" id="buttonbox4">
+                      <object class="GtkButtonBox" id="buttonsRow2">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="spacing">2</property>
@@ -403,16 +403,16 @@ All Tags</property>
               </packing>
             </child>
             <child>
-              <object class="GtkBox" id="box2">
+              <object class="GtkBox" id="mainBox">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkPaned" id="paned2">
+                  <object class="GtkPaned" id="mainTopBox">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <child>
-                      <object class="GtkBox" id="box3">
+                      <object class="GtkBox" id="videoAndControlsBox">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="orientation">vertical</property>
@@ -456,7 +456,7 @@ All Tags</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkButtonBox" id="buttonbox2">
+                          <object class="GtkButtonBox" id="videoControlsBox">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="halign">center</property>

--- a/cave/gui/cave.glade
+++ b/cave/gui/cave.glade
@@ -418,7 +418,7 @@ All Tags</property>
                         <property name="orientation">vertical</property>
                         <child>
                           <object class="GtkFrame" id="videoFrame">
-                            <property name="width_request">400</property>
+                            <property name="width_request">100</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label_xalign">0</property>
@@ -479,49 +479,6 @@ All Tags</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkBox" id="box6">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="orientation">vertical</property>
-                                <child>
-                                  <object class="GtkCheckButton" id="exportCheck">
-                                    <property name="label" translatable="yes">Pipe frames to Vision</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Run "auv-visiond cave_test" to view these frames</property>
-                                    <property name="draw_indicator">True</property>
-                                    <signal name="toggled" handler="frames_to_vision_checked" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkButton" id="button4">
-                                <property name="label" translatable="yes">Clear Tag</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="tooltip_text" translatable="yes">Clear data in the currently selected tag for the current frame</property>
-                                <signal name="clicked" handler="clear_tag" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                            <child>
                               <object class="GtkToggleButton" id="loopButton">
                                 <property name="label" translatable="yes">Replay Section</property>
                                 <property name="visible">True</property>
@@ -554,48 +511,7 @@ All Tags</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="orientation">vertical</property>
-                        <child>
-                          <object class="GtkFrame" id="informationFrame">
-                            <property name="width_request">100</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label_xalign">0</property>
-                            <property name="shadow_type">none</property>
-                            <child>
-                              <object class="GtkAlignment" id="alignment1">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="left_padding">12</property>
-                                <child>
-                                  <object class="GtkLabel" id="label4">
-                                    <property name="width_request">0</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="valign">start</property>
-                                    <property name="label" translatable="yes">Name:
-Path:
-Log:</property>
-                                    <property name="ellipsize">end</property>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
-                            <child type="label">
-                              <object class="GtkLabel" id="label2">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">&lt;b&gt;Information&lt;/b&gt;</property>
-                                <property name="use_markup">True</property>
-                              </object>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
+                        <property name="baseline_position">top</property>
                         <child>
                           <object class="GtkFrame" id="Settings">
                             <property name="visible">True</property>
@@ -652,6 +568,23 @@ if performance is a concern (low powered systems)</property>
                                         <property name="position">1</property>
                                       </packing>
                                     </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="exportCheck">
+                                        <property name="label" translatable="yes">Pipe frames
+to Vision</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="tooltip_text" translatable="yes">Run "auv-visiond cave_test" to view these frames</property>
+                                        <property name="draw_indicator">True</property>
+                                        <signal name="toggled" handler="frames_to_vision_checked" swapped="no"/>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
                                   </object>
                                 </child>
                               </object>
@@ -670,6 +603,60 @@ if performance is a concern (low powered systems)</property>
                             <property name="fill">True</property>
                             <property name="padding">20</property>
                             <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkFrame" id="Tagging">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label_xalign">0</property>
+                            <property name="shadow_type">none</property>
+                            <child>
+                              <object class="GtkAlignment" id="alignment1">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="xalign">0</property>
+                                <property name="yalign">0</property>
+                                <child>
+                                  <object class="GtkButtonBox" id="TaggingButtons">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="orientation">vertical</property>
+                                    <property name="spacing">5</property>
+                                    <property name="layout_style">start</property>
+                                    <child>
+                                      <object class="GtkButton" id="tagClearButton">
+                                        <property name="label" translatable="yes">Clear Tag</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">True</property>
+                                        <property name="tooltip_text" translatable="yes">Clear data in the currently selected tag for the current frame</property>
+                                        <signal name="clicked" handler="clear_tag" swapped="no"/>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                            <child type="label">
+                              <object class="GtkLabel" id="label2">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="label" translatable="yes">&lt;b&gt;Tagging&lt;/b&gt;</property>
+                                <property name="use_markup">True</property>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="padding">20</property>
+                            <property name="position">2</property>
                           </packing>
                         </child>
                       </object>

--- a/cave/gui/editvideo.glade
+++ b/cave/gui/editvideo.glade
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.0 -->
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.10"/>
   <object class="GtkDialog" id="editVideoWindow">
     <property name="can_focus">False</property>
     <property name="border_width">5</property>

--- a/cave/gui/testwindow.glade
+++ b/cave/gui/testwindow.glade
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.0 -->
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.10"/>
   <object class="GtkWindow" id="testWindow">
     <property name="width_request">300</property>
     <property name="can_focus">False</property>
@@ -146,12 +147,10 @@ dropdown below to restrict the test.</property>
                 <child>
                   <object class="GtkButton" id="startButton">
                     <property name="label" translatable="yes">Start Test</property>
-                    <property name="use_action_appearance">False</property>
                     <property name="width_request">120</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="use_action_appearance">False</property>
                     <signal name="clicked" handler="start_click" swapped="no"/>
                   </object>
                   <packing>
@@ -163,12 +162,10 @@ dropdown below to restrict the test.</property>
                 <child>
                   <object class="GtkButton" id="trainButton">
                     <property name="label" translatable="yes">Start Train Mode</property>
-                    <property name="use_action_appearance">False</property>
                     <property name="width_request">120</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="use_action_appearance">False</property>
                     <signal name="clicked" handler="starttrain_click" swapped="no"/>
                   </object>
                   <packing>
@@ -180,12 +177,10 @@ dropdown below to restrict the test.</property>
                 <child>
                   <object class="GtkButton" id="videoSplitButton">
                     <property name="label" translatable="yes">Split Videos Into Tags</property>
-                    <property name="use_action_appearance">False</property>
                     <property name="width_request">120</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="use_action_appearance">False</property>
                     <signal name="clicked" handler="start_split_video_click" swapped="no"/>
                   </object>
                   <packing>
@@ -204,12 +199,10 @@ dropdown below to restrict the test.</property>
             <child>
               <object class="GtkButton" id="abortButton">
                 <property name="label" translatable="yes">Abort Test</property>
-                <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_action_appearance">False</property>
                 <signal name="clicked" handler="abort_click" swapped="no"/>
               </object>
               <packing>

--- a/cave/main.py
+++ b/cave/main.py
@@ -36,9 +36,9 @@ from misc.utils import register_exit_signals
 
 load_tag_modules()
 
-__location__ = os.path.dirname(os.path.realpath(os.path.abspath(sys.argv[0]))) 
+__location__ = os.path.dirname(os.path.realpath(os.path.abspath(sys.argv[0])))
 
-ap = argparse.ArgumentParser(description='CUAUV Automated Vision Evaluator: A program for video ' + 
+ap = argparse.ArgumentParser(description='CUAUV Automated Vision Evaluator: A program for video ' +
         'database management and automated vision testing')
 ap.add_argument('database', type=str, default="", nargs='?', help='filename of the database to load (optional)')
 ap.add_argument('--filter', type=str, default="", help='filename of the config file   \
@@ -56,7 +56,7 @@ class Cave:
     """
 
     config_file = "~/.cave"
-     
+
     def window_destroy(self, event):
         # Close this application
         self.logger.critical("Program shutdown!")
@@ -91,7 +91,7 @@ class Cave:
     #Add Video callback; compute paths and add video to database
     def database_add_callback(self, av):
         self.logger.debug("Callback executed")
-       
+
         if av.log_filename is None:
             log_path = ""
         else:
@@ -146,7 +146,7 @@ class Cave:
             self.statusbar.display("Opened database %s" % path, 3)
             self.logger.info("Opened database %s" % os.path.basename(path))
             self.video_tree_manager.redraw()
-            
+
             #Enable all operations
 
     def video_remove(self, event):
@@ -215,6 +215,19 @@ class Cave:
         button = self.builder.get_object("logCheck")
         self.logplayer.set_enabled(button.get_active())
 
+    def full_screen_checked(self, event):
+        button = self.builder.get_object("fullScreenCheck")
+        settings = self.builder.get_object("settingsBox")
+        panel = self.builder.get_object("panelBox")
+        if button.get_active():
+            self.log.info('Activating compact mode.')
+            settings.hide()
+            panel.hide()
+        else:
+            self.log.info('Disabling compact mode.')
+            settings.show()
+            panel.show()
+
     def enable_video_previews(self, event):
         button = self.builder.get_object("previewCheck")
         self.video_preview_manager.set_enabled(button.get_active())
@@ -233,7 +246,7 @@ class Cave:
         if vid_select is None:
             self.logger.error("Edit of video failed. No video was selected.")
             self.statusbar.display("No video selected", 3)
-        else:           
+        else:
             ev = EditVideo(self.edit_video_callback, vid_select)
 
     def edit_video_callback(self, av):
@@ -292,8 +305,8 @@ class Cave:
             query += tokenquery % tokens[-1]
         else:
             query = ""
-        
-        self.video_tree_manager.redraw(query) 
+
+        self.video_tree_manager.redraw(query)
 
     def _change_frame(self, frame):
         #Sets the videobox and logplayer frame
@@ -309,7 +322,7 @@ class Cave:
         # Automatically connect signals to functions defined above
         self.builder.connect_signals(self)
 
-        #Set up the video tree 
+        #Set up the video tree
         self.video_tree = self.builder.get_object("videoTreeView")
         self.video_tree_manager = VideoTreeManager(self.video_tree, self)
 
@@ -321,7 +334,7 @@ class Cave:
         self.video_box = VideoBox(self)
         self.video_box.show()
         self.video_box_container.pack_start(self.video_box, True, True, 0)
-        
+
         #Create & Link timeline widget
         self.timeline_box = self.builder.get_object("timelineBox")
         self.timeline = Timeline(self)
@@ -390,7 +403,7 @@ class Cave:
         #Make the window more shrinkable
         self.window.set_size_request(400,400)
 
-        #Fire up the main window 
+        #Fire up the main window
         self.log.info("Launching GUI. Welcome to CAVE!")
         self.init = True
         Gdk.threads_enter()

--- a/cave/testwindow.py
+++ b/cave/testwindow.py
@@ -22,7 +22,7 @@ except ImportError:
     print "Warning: pygame is not installed, there will be no sound!"
     pygame_present = False
 
-__location__ = os.path.dirname(os.path.realpath(os.path.abspath(sys.argv[0]))) 
+__location__ = os.path.dirname(os.path.realpath(os.path.abspath(sys.argv[0])))
 
 @with_logging
 class TestWindow:
@@ -144,7 +144,7 @@ class TestWindow:
         start_enabled = self.total_frames > 0
         self.builder.get_object("startButton").set_sensitive(start_enabled)
         self.builder.get_object("trainButton").set_sensitive(start_enabled)
- 
+
 
     def __init__(self, parent):
         self.gladefile = os.path.join(__location__, "gui/testwindow.glade")
@@ -154,10 +154,10 @@ class TestWindow:
         self.t = None
         self.last_frame_time = None
         self.fps_hysteresis = TimedHysteresis(1.0) #1 second hysteresis
-        
+
         # Automatically connect signals to functions defined above
         self.builder.connect_signals(self)
-        
+
         self.mission_element_combo = self.builder.get_object("missionElementCombo")
         self.tag_type_combo = self.builder.get_object("tagTypeCombo")
         self.tag_name_entry = self.builder.get_object("tagNameEntry")
@@ -184,6 +184,7 @@ class TestWindow:
 
         #Get the main window
         self.window = self.builder.get_object("testWindow")
+        self.window.set_type_hint(Gdk.WindowTypeHint.DIALOG)
         self.window.show()
 
         #Disable the trees to prevent modifications

--- a/cave/timeline.py
+++ b/cave/timeline.py
@@ -29,7 +29,7 @@ DATA_NEG = (0.8, 0.0, 0.0)
 DATA_RESULT_HEIGHT = 5
 
 PREVIEW_Y = 45
-PREVIEW_HEIGHT = 45 
+PREVIEW_HEIGHT = 45
 PREVIEW_WIDTH = 60
 
 X_BETWEEN_LABELS = 80
@@ -63,7 +63,7 @@ class Timeline(Gtk.DrawingArea):
         Gtk.DrawingArea.__init__(self)
         self.connect('draw', self._do_expose)
         self.set_events(Gdk.EventMask.BUTTON_PRESS_MASK | Gdk.EventMask.BUTTON_MOTION_MASK | Gdk.EventMask.SCROLL_MASK |
-                Gdk.EventMask.BUTTON_RELEASE_MASK)        
+                Gdk.EventMask.BUTTON_RELEASE_MASK)
         self.connect("button-press-event", self._click) #mouse button is pressed (either left or right)
         self.connect("motion-notify-event", self._drag) #mouse is held down and in motion
         self.connect("button-release-event", self._release) #button was released
@@ -72,12 +72,12 @@ class Timeline(Gtk.DrawingArea):
         self.connect("scroll-event", self._scroll)
         self.set_size_request (400, 125)
 
-        self.x = 90 
+        self.x = 90
         self.y = 5
 
         self.view_start = 0 #Frame where view starts
         self.view_end = 100 #Frame where view ends
-    
+
         self.length = 100 #Number of frames within the timeline (can be changed)
 
         self.cursor = 0 #Frame at which to display the cursor
@@ -91,7 +91,7 @@ class Timeline(Gtk.DrawingArea):
         self.loop_end = float('nan')
         self.loop_enabled = False
         self.loop_set = False
-        
+
         #Callbacks
         self.cursor_change = None
 
@@ -185,7 +185,7 @@ class Timeline(Gtk.DrawingArea):
         self.origin_mouse = (event.x, event.y)
         self.origin_start = self.view_start
         self.origin_end = self.view_end
-       
+
         #Classify the click and assign click state (so that drag knows how to operate)
         if event.y >= a.height - SCROLL_HEIGHT: #Somewhere in scrollbar area clicked
             x_start = float(self.view_start) / self.length * a.width
@@ -205,9 +205,9 @@ class Timeline(Gtk.DrawingArea):
                 self.loop_start_temp = start_frame
                 self.loop_dragging = False
 
-        else: #Clicked the main region 
+        else: #Clicked the main region
             self.cs = CS.MAIN
-        
+
     def _release(self, area, event):
         if (self.cs == CS.CURSOR) and self.loop_enabled and self.loop_dragging:
             end_frame = self.get_frame(event.x)
@@ -266,7 +266,7 @@ class Timeline(Gtk.DrawingArea):
         dframes = int(dx / a.width * self.length)
 
         dlocalframes = -1 * int(dx / a.width * (self.origin_end - self.origin_start))
-      
+
         #Click and drag on the main area to seek
         if self.cs == CS.MAIN:
             ns = self.origin_start + dlocalframes
@@ -274,7 +274,7 @@ class Timeline(Gtk.DrawingArea):
             if ns >= 0 and ne <= self.length:
                 self.view_start = ns
                 self.view_end = ne
-            
+
         ### Scrollbar
         if self.cs == CS.SBAR:
             ns = self.origin_start + dframes
@@ -294,7 +294,7 @@ class Timeline(Gtk.DrawingArea):
         ### Cursor
         if self.cs == CS.CURSOR:
             self._change_cursor(event.x)
-                
+
         self.queue_draw()
 
     def preview_callback(self, frame_number, video):
@@ -309,10 +309,10 @@ class Timeline(Gtk.DrawingArea):
         width = allocation.width
         height = allocation.height
         self.available_width = width
-        
+
         #Draw frame ticks
         ticks = list(enumerate(range(self.view_start, self.view_end)))
-        
+
         cr.set_source_rgb(*TICK_COLOR)
         if len(ticks) < 1500:
             cr.set_line_width(1.0)
@@ -325,7 +325,7 @@ class Timeline(Gtk.DrawingArea):
             #There are so many frames that we can just draw a massive rectangle at this point
             cr.rectangle(0,0, width, TICK_HEIGHT)
             cr.fill()
-            
+
         #Label some of them ticks
         cr.set_source_rgb(0.3,0.3,0.3)
         cr.set_font_size(10)
@@ -347,7 +347,7 @@ class Timeline(Gtk.DrawingArea):
                 segment = map(operator.itemgetter(1),g)
                 first_frame = segment[0]
                 last_frame = segment[-1]
-                
+
                 #Draw box for the tag segment
                 x_start = int(float(first_frame - self.view_start) / len(ticks) * width)
                 x_end = int(float(last_frame + 1 - self.view_start) / len(ticks) * width)
@@ -363,7 +363,7 @@ class Timeline(Gtk.DrawingArea):
 
             cr.set_source_rgb(*DATA_POS)
             draw_frame_range(tag_select.test_pos, DATA_RESULT_HEIGHT)
-            
+
             cr.set_source_rgb(*DATA_NEG)
             draw_frame_range(tag_select.test_neg, DATA_RESULT_HEIGHT)
 
@@ -376,7 +376,7 @@ class Timeline(Gtk.DrawingArea):
             requested_frames.append(i)
             if frame is not None:
                 x = int((float(i) - self.view_start) / (self.view_end - self.view_start) * width)
-                cr.set_source_surface(frame, x, PREVIEW_Y) 
+                cr.set_source_surface(frame, x, PREVIEW_Y)
                 cr.paint()
             i += preview_frames
         self.video_preview_manager.clear_all_requests_except(requested_frames)
@@ -433,16 +433,14 @@ class Timeline(Gtk.DrawingArea):
         cr.move_to(x, height-SCROLL_HEIGHT)
         cr.line_to(x, height)
         cr.stroke()
-        
+
         #Draw scrollbar outline
         cr.set_source_rgb(0.0,0,0)
         cr.set_line_width(2.0)
         cr.rectangle(0, height-SCROLL_HEIGHT, width, SCROLL_HEIGHT)
         cr.stroke()
-       
+
         #Cursor text
         cr.set_source_rgb(0.3,0.3,0.3)
         cr.move_to(2, height-SCROLL_HEIGHT - 5)
         cr.show_text("Frame: %d" % self.cursor)
-
-        cr.save()

--- a/cave/videobox.py
+++ b/cave/videobox.py
@@ -340,5 +340,3 @@ class VideoBox(Gtk.DrawingArea):
         #Draw tag-related components
         if self.tag_type_instance is not None:
             self.tag_type_instance.draw(widget, cr, vid_x_o, vid_y_o)
-
-        cr.save()

--- a/cave/videobox.py
+++ b/cave/videobox.py
@@ -189,7 +189,7 @@ class VideoBox(Gtk.DrawingArea):
         self.connect("leave-notify-event", self._exit)
         self.connect("key-press-event", self._keypress)
         self.connect("scroll-event", self._scroll)
-        self.set_size_request (640, 480)
+        self.set_size_request(320, 240)
 
         self.frame = None
         self.video = None
@@ -325,18 +325,32 @@ class VideoBox(Gtk.DrawingArea):
         frame_width = allocation.width
         frame_height = allocation.height
 
+        if self.tag_type_instance is None:
+            scale_factor = min(float(frame_height) / self.height,
+                               float(frame_width) / self.width)
+        else:
+            scale_factor = 1.0
+
         #Video origin
-        vid_x_o = frame_width / 2 - self.width / 2
-        vid_y_o = frame_height / 2 - self.height / 2
+        vid_x_o = (frame_width / 2 / scale_factor - self.width / 2)
+        vid_y_o = (frame_height / 2 / scale_factor - self.height / 2)
 
         if self.frame is None:
             # Nothing to draw!
             return
 
         #Draw the video frame
+        cr.scale(scale_factor, scale_factor)
         cr.set_source_surface(self.frame, vid_x_o, vid_y_o)
         cr.paint()
 
         #Draw tag-related components
         if self.tag_type_instance is not None:
             self.tag_type_instance.draw(widget, cr, vid_x_o, vid_y_o)
+
+            # Warn that auto-scale was disabled.
+            cr.set_source_rgb(0.7,0,0)
+            cr.move_to(0, frame_height - 5)
+            # This is mostly because I'm too lazy right now to implement
+            # the rescaling logic needed for tagging.
+            cr.show_text("Video auto-scaling disabled in tagging mode.")

--- a/cave/videobox.py
+++ b/cave/videobox.py
@@ -25,7 +25,7 @@ class VideoManagerThread(Thread):
     def __init__(self, callback):
         Thread.__init__(self)
         self.next_frame = None
-        self.camlink = None 
+        self.camlink = None
         self.callback = callback
         self.video = None
         self.c = Condition()
@@ -39,7 +39,7 @@ class VideoManagerThread(Thread):
         self.last_frame = None #Last frame number captured
 
         self.new_link = None
-        
+
         self.start()
 
     def new_camlink(self, name, height, width, nchannels):
@@ -208,7 +208,7 @@ class VideoBox(Gtk.DrawingArea):
         frame_height = allocation.height
 
         #Video origin
-        vid_x_o = frame_width / 2 - self.width / 2 
+        vid_x_o = frame_width / 2 - self.width / 2
         vid_y_o = frame_height / 2 - self.height / 2
 
         return int(sx - vid_x_o), int(sy - vid_y_o)
@@ -276,14 +276,14 @@ class VideoBox(Gtk.DrawingArea):
         if self.vmt is not None:
             self.vmt.destroy()
 
-    #Sets a tag for use here 
+    #Sets a tag for use here
     def set_tag(self, tag):
         if tag is None:
             self.tag_type_instance = None
         else:
             TagTypeClass = get_class_from_tagtype(tag.tag_type)
-            self.tag_type_instance = TagTypeClass(tag, lambda : self.parent.timeline.cursor) 
-    
+            self.tag_type_instance = TagTypeClass(tag, lambda : self.parent.timeline.cursor)
+
     #Loads a new video for playback
     #@supress_output
     def load_video(self, video):
@@ -308,7 +308,7 @@ class VideoBox(Gtk.DrawingArea):
         self.cap_source_cache[video] = cap
 
         self.vmt.new_camlink(video.linked_camera, self.height, self.width, self.nchannels)
-        
+
         self.vmt.set_cap(cap, video)
         self.vmt.request_frame(0)
 
@@ -316,7 +316,7 @@ class VideoBox(Gtk.DrawingArea):
     def set_frame(self, frame):
         frame = max(0, min(self.length, frame)) #bounds check
         self.vmt.request_frame(frame)
-    
+
     #Carries out on-screen drawing when queue_draw is called
     def _do_expose(self, widget, cr):
 
@@ -326,16 +326,19 @@ class VideoBox(Gtk.DrawingArea):
         frame_height = allocation.height
 
         #Video origin
-        vid_x_o = frame_width / 2 - self.width / 2 
+        vid_x_o = frame_width / 2 - self.width / 2
         vid_y_o = frame_height / 2 - self.height / 2
 
+        if self.frame is None:
+            # Nothing to draw!
+            return
+
         #Draw the video frame
-        if self.frame is not None:
-            cr.set_source_surface(self.frame, vid_x_o, vid_y_o)
-            cr.paint()
+        cr.set_source_surface(self.frame, vid_x_o, vid_y_o)
+        cr.paint()
 
         #Draw tag-related components
         if self.tag_type_instance is not None:
             self.tag_type_instance.draw(widget, cr, vid_x_o, vid_y_o)
-        
+
         cr.save()

--- a/cave/videoplayer.py
+++ b/cave/videoplayer.py
@@ -20,16 +20,16 @@ class VideoPlayer(Thread):
         self.kill = Event()
 
         self.parent = parent
-        
+
         self.video_box = parent.video_box
 
         self.start()
-    
+
     def set_play(self, play):
         with self.c:
             self.play = play
             self.c.notify()
-        
+
     def destroy(self):
         with self.c:
             self.kill.set()
@@ -42,7 +42,7 @@ class VideoPlayer(Thread):
                     self.c.wait()
                     if self.kill.is_set():
                         break
-            
+
             #Playing, increment frame count
             t1 = time()
             Gdk.threads_enter()


### PR DESCRIPTION
## Release Notes
- GTK templates updated from 3.0 to 3.10 (should be supported by Ubuntu 14.04+)
- GTK render bugs fixed. Apparently the new GTK versions don't like saving the cairo context (2 line fix.)
- Added "fit-to-window" scaling for the video display
- Added a couple things to make tiling window manager users happier
- Minor UI reorganization
## Images

Broken, sad UI:
![broken_ui](https://cloud.githubusercontent.com/assets/2321525/17354277/f952901e-58fb-11e6-9df8-82cfa3df4234.png)

Happy, fixed UI:
![happy_ui](https://cloud.githubusercontent.com/assets/2321525/17354279/ff2171ae-58fb-11e6-8692-5d2fc740d1dc.png)

New "compact" mode:
![compact](https://cloud.githubusercontent.com/assets/2321525/17354290/10eebc7a-58fc-11e6-9025-7984b88ce2b4.png)

Happy CAVEing!
